### PR TITLE
Change keystone-utils version number due to issue deploying on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grappling-hook": "^3.0.0",
     "jade": "^1.11.0",
     "jquery": "^2.1.4",
-    "keystone-utils": "^0.3.0",
+    "keystone-utils": "0.3.4",
     "knox": "^0.9.2",
     "less-middleware": "^2.0.1",
     "list-to-array": "^1.1.0",


### PR DESCRIPTION
Keystone-utils was updated to version 0.3.5 yesterday which included some dependency updates to new packages. Installing the new version of keystone-utils worked in the local environment but during the install on Heroku, it kept failing (build log is attached at the bottom of this CR). This CR is to keep the version of Keystone-utils at 0.3.4 until this issue has been resolved.

```
   > unicode-json@1.0.0 postinstall /tmp/build_f9fa35c49b480d66133a4162bad1592c/node_modules/unicode-json
   > node install.js

   try to read file /usr/share/unicode/UnicodeData.txt…
   /usr/share/unicode/UnicodeData.txt not found.
   try to read file /usr/share/unicode-data/UnicodeData.txt…
   /usr/share/unicode-data/UnicodeData.txt not found.
   try to read file UnicodeData.txt…
   UnicodeData.txt not found.
   try to download…
   GET http://unicode.org:80/Public/UNIDATA/UnicodeData.txt
   fetching…
   try to read file /usr/share/unicode/UnicodeData.txt…
   /usr/share/unicode/UnicodeData.txt not found.
   try to read file /usr/share/unicode-data/UnicodeData.txt…
   /usr/share/unicode-data/UnicodeData.txt not found.
   try to read file UnicodeData.txt…
   parsing…

   readline.js:73
   terminal = !!output.isTTY;
   ^
   TypeError: Cannot read property 'isTTY' of undefined
   at new Interface (readline.js:73:24)
   at Object.exports.createInterface (readline.js:39:10)
   at /tmp/build_f9fa35c49b480d66133a4162bad1592c/node_modules/unicode-json/install.js:77:25
   at Object.cb [as oncomplete] (fs.js:168:19)
   keystone-legal-model@0.0.0 /tmp/build_f9fa35c49b480d66133a4162bad1592c

   npm ERR! Linux 3.13.0-85-generic
   npm ERR! argv "node" "/tmp/build_f9fa35c49b480d66133a4162bad1592c/.heroku/node/bin/npm" "install" "--unsafe-perm" "--userconfig" "/tmp/build_f9fa35c49b480d66133a4162bad1592c/.npmrc"
   npm ERR! node v0.10.32
   npm ERR! npm  v3.8.9
   npm ERR! code ELIFECYCLE

   npm ERR! unicode-json@1.0.0 postinstall: `node install.js`
   npm ERR! Exit status 8
   npm ERR!
   npm ERR! Failed at the unicode-json@1.0.0 postinstall script 'node install.js'.
   npm ERR! Make sure you have the latest version of node.js and npm installed.
   npm ERR! If you do, this is most likely a problem with the unicode-json package,
   npm ERR! not with npm itself.
   npm ERR! Tell the author that this fails on your system:
   npm ERR!     node install.js
   npm ERR! You can get information on how to open an issue for this project with:
   npm ERR!     npm bugs unicode-json
   npm ERR! Or if that isn't available, you can get their info via:
   npm ERR!     npm owner ls unicode-json
   npm ERR! There is likely additional logging output above.

   npm ERR! Please include the following file with any support request:
   npm ERR!     /tmp/build_f9fa35c49b480d66133a4162bad1592c/npm-debug.log
```

-----> Build failed
